### PR TITLE
Rebrand application from Jira to Project Time Tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,24 @@
-# Jira Time Tracker
+# Project Time Tracker
 
-A cross-platform desktop application built with Nextron (Next.js + Electron) for tracking time spent on Jira tickets. The application provides a rich interface featuring both a comprehensive main dashboard and a compact floating timer, designed to help developers and teams accurately track time across multiple projects and tickets.
+A cross-platform desktop application built with Nextron (Next.js + Electron) for tracking time spent on Project tickets. The application provides a rich interface featuring both a comprehensive main dashboard and a compact floating timer, designed to help developers and teams accurately track time across multiple projects and tickets.
 
 ## Key Features
 
 ### 🎯 Ticket-Based Time Tracking
-- **Start, pause, resume, hold, complete, and stop timers** for specific Jira ticket numbers
+
+- **Start, pause, resume, hold, complete, and stop timers** for specific Project ticket numbers
 - **Session recording** with detailed logging of startTime, endTime, duration, and status
 - **Accumulated time tracking** showing both current session elapsed time and total time across all sessions
 - **Multiple timer support** for managing several tickets simultaneously
 
 ### 📊 Story Point Integration
+
 - **Assign story point estimates** to tickets for better project planning
 - **Progress visualization** with real-time progress bars showing completion against estimated time
 - **Productivity metrics** tracking story points completed per day
 
 ### 💾 Persistent Local Storage
+
 - **Secure local data storage** using electron-store for sessions, settings, and configuration
 - **Data persistence** across application restarts without requiring external databases
 - **Cross-platform compatibility** with consistent data storage across Windows, macOS, and Linux
@@ -23,24 +26,28 @@ A cross-platform desktop application built with Nextron (Next.js + Electron) for
 ### 🖥️ Dual Interface Design
 
 #### Main Dashboard Window
+
 - **Comprehensive project overview** with statistics and metrics
 - **Ticket management** with search and filtering capabilities
 - **Project path integration** for developer workflows
 - **Data export functionality** in multiple formats
 
 #### Floating Timer Window
+
 - **Always-on-top** compact timer display
 - **Draggable positioning** for optimal screen placement
 - **Expandable/collapsible** interface for space optimization
 - **Real-time timer updates** with visual progress indicators
 
 ### 🔧 System Integration
+
 - **System tray integration** with quick access to all functions
 - **Keyboard shortcuts** for rapid timer control
 - **Desktop notifications** for break reminders and timer updates
 - **Git branch detection** for project-specific workflows
 
 ### 🎨 User Experience
+
 - **Theme support** with light, dark, and system theme options
 - **Responsive design** optimized for different screen sizes
 - **Intuitive controls** with clear visual feedback
@@ -48,17 +55,20 @@ A cross-platform desktop application built with Nextron (Next.js + Electron) for
 ### 💪 Productivity & Wellness Features
 
 #### Break Reminders (Pomodoro Technique)
+
 - **Configurable work/break cycles** with customizable durations
 - **Long break intervals** for extended work sessions
 - **Desktop notifications** with contextual productivity tips
 - **Flexible break management** with options to start, skip, or postpone breaks
 
 #### Idle Detection
+
 - **Automatic timer pausing** when system inactivity is detected
 - **Accurate time logging** preventing overestimation due to breaks
 - **Manual resume** requirement to ensure intentional time tracking
 
 #### Time Goals Widget
+
 - **Daily and project-specific goals** with progress tracking
 - **Visual progress indicators** showing completion percentages
 - **Achievement notifications** for meeting or exceeding goals
@@ -67,12 +77,14 @@ A cross-platform desktop application built with Nextron (Next.js + Electron) for
 ### 📈 Data Management & Reporting
 
 #### Export Functionality
+
 - **Multiple export formats** including CSV (Excel-compatible) and JSON
 - **Flexible filtering** by date range and project names
 - **Export summaries** showing total sessions, time, projects, and tickets
 - **Data validation** ensuring export integrity
 
 #### Analytics Dashboard
+
 - **Productivity metrics** including tickets per day and points per day
 - **Time analysis** with average time per ticket and per story point
 - **Project comparisons** across different repositories and teams
@@ -81,11 +93,13 @@ A cross-platform desktop application built with Nextron (Next.js + Electron) for
 ### 🛠️ Developer Integration Features
 
 #### Project Path Management
+
 - **Local directory selection** for project-specific features
 - **Git repository integration** with automatic branch detection
 - **Multi-project support** with saved paths and configurations
 
 #### GitHub Actions Integration
+
 - **Workflow triggering** directly from the application
 - **CI/CD integration** using GitHub CLI (gh) tool
 - **Project-specific actions** based on selected repository paths
@@ -104,6 +118,7 @@ A cross-platform desktop application built with Nextron (Next.js + Electron) for
 ## Installation
 
 ### Prerequisites
+
 - Node.js (version 16 or higher)
 - npm, yarn, or pnpm package manager
 - Git (for project path features)
@@ -112,12 +127,14 @@ A cross-platform desktop application built with Nextron (Next.js + Electron) for
 ### Setup Instructions
 
 1. **Clone the repository:**
+
    ```bash
-   git clone https://github.com/your-username/jira-time-tracker.git
-   cd jira-time-tracker
+   git clone https://github.com/your-username/project-time-tracker.git
+   cd project-time-tracker
    ```
 
 2. **Install dependencies:**
+
    ```bash
    npm install
    # or
@@ -126,8 +143,9 @@ A cross-platform desktop application built with Nextron (Next.js + Electron) for
    pnpm install
    ```
 
-3. **Set up Jira data:**
-   - Ensure `json/data.json` exists with your Jira ticket data
+3. **Set up Project data:**
+
+   - Ensure `json/data.json` exists with your Project ticket data
    - The file should contain an array of objects with `ticket_number`, `ticket_name`, and `story_points` properties
 
 4. **Configure environment (optional):**
@@ -137,32 +155,41 @@ A cross-platform desktop application built with Nextron (Next.js + Electron) for
 ## Usage
 
 ### Development Mode
+
 Start the application in development mode:
+
 ```bash
 npm run dev
 ```
+
 This launches the Electron app with hot-reloading enabled for development.
 
 ### Production Build
+
 Create a production build:
+
 ```bash
 npm run build
 ```
+
 The packaged application will be output to the `dist/` directory.
 
 ### Basic Usage
 
 1. **Starting a Timer:**
+
    - Use the floating timer window or main dashboard
-   - Select a Jira ticket from the dropdown
+   - Select a Project ticket from the dropdown
    - Click "Start" to begin tracking time
 
 2. **Managing Sessions:**
+
    - Pause/resume timers as needed
    - Mark tasks as complete when finished
    - View session history in the main dashboard
 
 3. **System Tray Access:**
+
    - Right-click the system tray icon for quick actions
    - Toggle floating timer visibility
    - Access main window and settings
@@ -173,6 +200,7 @@ The packaged application will be output to the `dist/` directory.
    - Filter by specific projects if needed
 
 ### Keyboard Shortcuts
+
 - **Toggle floating timer:** Configurable global hotkey
 - **Start/pause current timer:** Available in floating window
 - **Navigate between tickets:** Arrow keys in timer selection
@@ -181,20 +209,23 @@ The packaged application will be output to the `dist/` directory.
 
 All application data is stored locally using `electron-store`, which creates JSON files in the system's user data directory:
 
-- **Windows:** `%APPDATA%/jira-time-tracker/`
-- **macOS:** `~/Library/Application Support/jira-time-tracker/`
-- **Linux:** `~/.config/jira-time-tracker/`
+- **Windows:** `%APPDATA%/project-time-tracker/`
+- **macOS:** `~/Library/Application Support/project-time-tracker/`
+- **Linux:** `~/.config/project-time-tracker/`
 
 ### Data Structure
+
 - **Sessions:** Timer sessions with start/end times, duration, and status
 - **Settings:** User preferences, theme settings, and break configurations
 - **Project Paths:** Local directory paths for Git integration
-- **Jira Data:** Cached ticket information and story points
+- **Project Data:** Cached ticket information and story points
 
 ## Configuration
 
-### Jira Data Format
+### Project Data Format
+
 The `json/data.json` file should follow this structure:
+
 ```json
 [
   {
@@ -211,6 +242,7 @@ The `json/data.json` file should follow this structure:
 ```
 
 ### Break Timer Configuration
+
 - Work duration: 25 minutes (default)
 - Short break: 5 minutes (default)
 - Long break: 15 minutes (default)
@@ -223,6 +255,7 @@ All timing settings can be customized through the application interface.
 Contributions are welcome! Please feel free to submit issues, feature requests, or pull requests.
 
 ### Development Setup
+
 1. Fork the repository
 2. Create a feature branch: `git checkout -b feature-name`
 3. Make your changes and test thoroughly
@@ -231,12 +264,14 @@ Contributions are welcome! Please feel free to submit issues, feature requests, 
 6. Submit a pull request
 
 ### Code Style
+
 - Follow TypeScript best practices
 - Use existing component patterns and conventions
 - Maintain consistent code formatting
 - Add comments for complex logic
 
 ### Testing
+
 - Test all new features in development mode
 - Verify cross-platform compatibility when possible
 - Test data persistence and export functionality

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,18 +1,18 @@
-# Jira Time Tracking Application Features
+# Project Time Tracking Application Features
 
-This project is a **Jira Time Tracking application** built using **Nextron (Next.js + Electron)**, designed to help users efficiently track time spent on Jira tickets. It features a desktop application interface with both a main window and a compact floating timer.
+This project is a **Project Time Tracking application** built using **Nextron (Next.js + Electron)**, designed to help users efficiently track time spent on Project tickets. It features a desktop application interface with both a main window and a compact floating timer.
 
 ## Core Time Tracking & Session Management
 
 1.  **Ticket-Based Time Tracking:**
-    *   Allows users to start, pause, resume, hold, complete, and stop timers associated with specific Jira ticket numbers.
+    *   Allows users to start, pause, resume, hold, complete, and stop timers associated with specific Project ticket numbers.
     *   Tracks `elapsedTime` for the current session and `totalElapsed` time across all sessions for a given ticket.
-    *   Supports associating Jira tickets with `storyPoints` for estimated vs. actual time tracking.
+    *   Supports associating Project tickets with `storyPoints` for estimated vs. actual time tracking.
 2.  **Detailed Session Recording:**
     *   Each timer activity (start, pause, resume, stop, complete, hold) creates or updates a "session" entry.
     *   Records `startTime`, `endTime`, `duration`, and `status` for each individual session.
 3.  **Persistent Data Storage:**
-    *   Utilizes `electron-store` to save all time tracking sessions and Jira data locally, ensuring data is retained across application restarts.
+    *   Utilizes `electron-store` to save all time tracking sessions and Project data locally, ensuring data is retained across application restarts.
     *   Centralized `DataManager` in the main process handles data read/write operations and broadcasts updates to all open windows.
 
 ## User Interface & Experience
@@ -59,8 +59,8 @@ This project is a **Jira Time Tracking application** built using **Nextron (Next
 
 ## Data Management & Reporting
 
-1.  **Jira Data Loading:**
-    *   Loads initial Jira ticket data from a local `json/data.json` file.
+1.  **Project Data Loading:**
+    *   Loads initial Project ticket data from a local `json/data.json` file.
     *   `useJiraData` hook handles fetching and refreshing this data for the renderer process.
 2.  **Export Functionality (`ExportDialog.tsx`):**
     *   Allows exporting recorded time data.

--- a/docs/floating_screen_and_time_goals.md
+++ b/docs/floating_screen_and_time_goals.md
@@ -1,6 +1,6 @@
-# Jira Time Track - Key Features: Time Goals and Floating Screen
+# Project Time Track - Key Features: Time Goals and Floating Screen
 
-This document explains two core features of the Jira Time Track application: Time Goals and the Floating Screen.
+This document explains two core features of the Project Time Track application: Time Goals and the Floating Screen.
 
 ## 1. Time Goals
 
@@ -41,7 +41,7 @@ The "Floating Screen" is a compact, always-on-top window that provides quick acc
 
 ### Key Features and Functionalities of the Floating Screen (`renderer/pages/float.tsx`)
 
-*   **Timer Display:** Shows a list of active Jira task timers with details like ticket number, name, total elapsed time, current session time, status (Running, Paused, On Hold, Completed, Stopped, In Queue), and estimated time based on Story Points with a progress bar.
+*   **Timer Display:** Shows a list of active Project task timers with details like ticket number, name, total elapsed time, current session time, status (Running, Paused, On Hold, Completed, Stopped, In Queue), and estimated time based on Story Points with a progress bar.
 *   **Timer Actions:** Allows users to directly control timers (Start, Pause, Resume, Hold, Complete, Stop, Delete).
 *   **Idle Detection Integration:** Automatically pauses active timers if the user becomes idle for a configurable duration. Displays a "Paused due to idle" message.
 *   **Break Reminder Integration:** Displays information about upcoming or active breaks, including time remaining. Provides quick access to break settings and options to end or skip breaks.

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,5 +1,5 @@
-appId: com.jira.timetrack
-productName: Jira Time Track
+appId: com.project.timetrack
+productName: Project Time Track
 copyright: Copyright © 2025
 directories:
   output: dist

--- a/main/dataManager.ts
+++ b/main/dataManager.ts
@@ -3,13 +3,13 @@ import Store from "electron-store";
 
 interface AppData {
   sessions: { [ticketNumber: string]: any };
-  jiraData: any[];
+  projectData: any[];
 }
 
 class DataManager {
   private store = new Store<AppData>({
     name: "app-data",
-    defaults: { sessions: {}, jiraData: [] },
+    defaults: { sessions: {}, projectData: [] },
   });
 
   private windows: Set<Electron.BrowserWindow> = new Set();
@@ -39,14 +39,14 @@ class DataManager {
     return this.store.get("sessions");
   }
 
-  // Jira data methods
-  setJiraData(data: any[]) {
-    this.store.set("jiraData", data);
-    this.broadcast("jira-data-updated", data);
+  // Project data methods
+  setProjectData(data: any[]) {
+    this.store.set("projectData", data);
+    this.broadcast("project-data-updated", data);
   }
 
-  getJiraData() {
-    return this.store.get("jiraData");
+  getProjectData() {
+    return this.store.get("projectData");
   }
 }
 

--- a/main/preload.ts
+++ b/main/preload.ts
@@ -10,7 +10,7 @@ const validChannels = [
   "resume-task",
   "stop-task",
   "toggle-float-window",
-  "load-jira-data",
+  "load-project-data",
   "get-project-paths",
   "save-project-paths",
   "select-project-directory",
@@ -24,8 +24,8 @@ const validChannels = [
   "get-sessions",
   "save-session",
   "sessions-updated",
-  "jira-data-updated",
-  "refresh-jira-data",
+  "project-data-updated",
+  "refresh-project-data",
   // Manual task channels
   "get-all-tasks",
   "get-manual-tasks",
@@ -51,7 +51,7 @@ const handler = {
   send(channel: string, ...args: any[]) {
     if (validChannels.includes(channel)) {
       console.log(`[IPC PRELOAD SEND] Channel: "${channel}"`, "Args:", args);
-      if (channel === "load-jira-data") {
+      if (channel === "load-project-data") {
         // For invoke, we need to return the promise
         const promise = originalIpcRendererInvoke.apply(ipcRenderer, [
           channel,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "my-nextron-app",
+  "name": "project-time-tracker",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "my-nextron-app",
+      "name": "project-time-tracker",
       "version": "1.0.0",
       "hasInstallScript": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "private": true,
-  "name": "jira-time-tracker",
-  "description": "A cross-platform desktop application for tracking time spent on Jira tickets with floating timer, productivity features, and comprehensive reporting",
-  "version": "1.0.0",
+  "name": "project-time-tracker",
+  "description": "A cross-platform desktop application for tracking time spent on Project tickets with floating timer, productivity features, and comprehensive reporting",
+  "version": "1.0.1",
   "author": "Developer",
   "main": "app/background.js",
   "scripts": {

--- a/renderer/components/ManualTaskDialog.tsx
+++ b/renderer/components/ManualTaskDialog.tsx
@@ -1,11 +1,11 @@
 import React, { useState, useEffect } from "react";
-import { JiraTicket } from "../types/electron";
+import { ProjectTicket } from "../types/electron";
 
 interface ManualTaskDialogProps {
   isOpen: boolean;
   onClose: () => void;
   onSave: (task: { ticket_number: string; ticket_name: string; story_points?: number }) => void;
-  editingTask?: JiraTicket | null;
+  editingTask?: ProjectTicket | null;
   existingTickets: string[];
 }
 

--- a/renderer/hooks/useJiraData.ts
+++ b/renderer/hooks/useJiraData.ts
@@ -1,8 +1,8 @@
 import { useState, useEffect } from "react";
-import type { JiraTicket } from "../types/electron";
+import type { ProjectTicket } from "../types/electron";
 
-export function useJiraData() {
-  const [data, setData] = useState<JiraTicket[]>([]);
+export function useProjectData() {
+  const [data, setData] = useState<ProjectTicket[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -11,14 +11,14 @@ export function useJiraData() {
 
     const loadData = async () => {
       try {
-        const result = await window.ipc.send("load-jira-data", undefined);
+        const result = await window.ipc.send("load-project-data", undefined);
         if (mounted) {
           setData(result);
           setError(null);
         }
       } catch (err) {
         if (mounted) {
-          setError("Failed to load Jira tickets. Please try again.");
+          setError("Failed to load Project tickets. Please try again.");
           console.error("Error loading data:", err);
         }
       } finally {
@@ -38,11 +38,11 @@ export function useJiraData() {
   const refreshData = async () => {
     setLoading(true);
     try {
-      const result = await window.ipc.send("load-jira-data", undefined);
+      const result = await window.ipc.send("load-project-data", undefined);
       setData(result);
       setError(null);
     } catch (err) {
-      setError("Failed to refresh Jira tickets. Please try again.");
+      setError("Failed to refresh Project tickets. Please try again.");
       console.error("Error refreshing data:", err);
     } finally {
       setLoading(false);

--- a/renderer/hooks/useSharedData.ts
+++ b/renderer/hooks/useSharedData.ts
@@ -2,7 +2,7 @@
 import { useState, useEffect } from "react";
 
 export function useSharedData() {
-  const [jiraData, setJiraData] = useState([]);
+  const [projectData, setProjectData] = useState([]);
   const [sessions, setSessions] = useState({});
   const [loading, setLoading] = useState(true);
 
@@ -14,7 +14,7 @@ export function useSharedData() {
           window.ipc.invoke("get-all-tasks"),
           window.ipc.invoke("get-sessions"),
         ]);
-        setJiraData(allTasks || []);
+        setProjectData(allTasks || []);
         setSessions(sessionData || {});
       } finally {
         setLoading(false);
@@ -22,20 +22,20 @@ export function useSharedData() {
     };
 
     // Listen for updates
-    const cleanupJira = window.ipc.on("jira-data-updated", () => {
-      // Reload all tasks when Jira data changes
-      window.ipc.invoke("get-all-tasks").then(setJiraData);
+    const cleanupProject = window.ipc.on("project-data-updated", () => {
+      // Reload all tasks when Project data changes
+      window.ipc.invoke("get-all-tasks").then(setProjectData);
     });
     const cleanupManual = window.ipc.on("manual-tasks-updated", () => {
       // Reload all tasks when manual tasks change
-      window.ipc.invoke("get-all-tasks").then(setJiraData);
+      window.ipc.invoke("get-all-tasks").then(setProjectData);
     });
     const cleanupSessions = window.ipc.on("sessions-updated", setSessions);
 
     loadData();
 
     return () => {
-      cleanupJira();
+      cleanupProject();
       cleanupManual();
       cleanupSessions();
     };
@@ -45,5 +45,5 @@ export function useSharedData() {
     window.ipc.send("save-session", sessionData);
   };
 
-  return { jiraData, sessions, loading, saveSession };
+  return { projectData, sessions, loading, saveSession };
 }

--- a/renderer/pages/float.tsx
+++ b/renderer/pages/float.tsx
@@ -86,7 +86,7 @@ const FloatingWindow: React.FC = () => {
     const loadTicketData = async () => {
       try {
         const data = (await window.ipc.send(
-          "load-jira-data",
+          "load-project-data",
           undefined
         )) as Array<{
           ticket_number: string;
@@ -99,7 +99,7 @@ const FloatingWindow: React.FC = () => {
           }, {} as { [key: string]: string });
           setTicketData(ticketMap);
         } else {
-          console.warn("load-jira-data did not return valid data", data);
+          console.warn("load-project-data did not return valid data", data);
         }
       } catch (error) {
         console.error("Failed to load ticket data:", error);

--- a/renderer/pages/home.tsx
+++ b/renderer/pages/home.tsx
@@ -39,7 +39,7 @@ interface DashboardStats {
 }
 
 export default function HomePage() {
-  const { jiraData: data, sessions, loading } = useSharedData();
+  const { projectData: data, sessions, loading } = useSharedData();
   const [searchTerm, setSearchTerm] = useState("");
   const [selectedProject, setSelectedProject] = useState<string | null>(null);
   const [projectPaths, setProjectPaths] = useState<Record<string, string>>({});
@@ -439,7 +439,7 @@ export default function HomePage() {
   return (
     <React.Fragment>
       <Head>
-        <title>Jira Time Tracker</title>
+        <title>Project Time Tracker</title>
       </Head>
       <div className="min-h-screen bg-gray-50 dark:bg-gray-900 py-8 px-4 sm:px-6 lg:px-8">
         <div className="max-w-7xl mx-auto">
@@ -453,7 +453,7 @@ export default function HomePage() {
               height={100}
             />
             <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-4">
-              Jira Time Tracker Dashboard
+              Project Time Tracker Dashboard
             </h1>
             <div className="flex justify-center gap-4 mb-4">
               <button
@@ -941,7 +941,7 @@ export default function HomePage() {
                               </p>
                               {data.length === 0 && (
                                 <p className="text-sm text-gray-400">
-                                  Load your Jira data to see tickets here
+                                  Load your Project data to see tickets here
                                 </p>
                               )}
                             </div>

--- a/renderer/types/electron.d.ts
+++ b/renderer/types/electron.d.ts
@@ -1,6 +1,6 @@
 // renderer/types/electron.d.ts
 
-export interface JiraTicket {
+export interface ProjectTicket {
   ticket_number: string;
   ticket_name: string;
   story_points: number;
@@ -39,7 +39,7 @@ export interface IpcHandler {
   send(channel: "pause-task", value: { ticket: string }): void;
   send(channel: "resume-task", value: { ticket: string }): void;
   send(channel: "stop-task", value: { ticket: string }): void;
-  send(channel: "load-jira-data", value?: undefined): Promise<JiraTicket[]>;
+  send(channel: "load-project-data", value?: undefined): Promise<ProjectTicket[]>;
   send(channel: "delete-task", value: { ticket: string }): void;
   send(channel: "save-project-paths", value: Record<string, string>): void;
   send(
@@ -49,7 +49,7 @@ export interface IpcHandler {
   send(channel: "show-main-window"): void;
 
   // Add invoke method
-  invoke(channel: "load-jira-data", value?: undefined): Promise<JiraTicket[]>;
+  invoke(channel: "load-project-data", value?: undefined): Promise<ProjectTicket[]>;
   invoke(channel: "get-project-paths"): Promise<Record<string, string>>;
   invoke(
     channel: "select-project-directory",
@@ -91,22 +91,22 @@ export interface IpcHandler {
     totalTickets: number;
     error?: string;
   }>;
-  invoke(channel: "get-manual-tasks"): Promise<JiraTicket[]>;
-  invoke(channel: "get-all-tasks"): Promise<JiraTicket[]>;
+  invoke(channel: "get-manual-tasks"): Promise<ProjectTicket[]>;
+  invoke(channel: "get-all-tasks"): Promise<ProjectTicket[]>;
   invoke(
     channel: "add-manual-task",
     data: { ticket_number: string; ticket_name: string; story_points?: number }
   ): Promise<{
     success: boolean;
-    task?: JiraTicket;
+    task?: ProjectTicket;
     error?: string;
   }>;
   invoke(
     channel: "update-manual-task",
-    data: { taskId: string; updates: Partial<JiraTicket> }
+    data: { taskId: string; updates: Partial<ProjectTicket> }
   ): Promise<{
     success: boolean;
-    task?: JiraTicket;
+    task?: ProjectTicket;
     error?: string;
   }>;
   invoke(
@@ -139,7 +139,7 @@ export interface IpcHandler {
   ): () => void;
   on(
     channel: "manual-tasks-updated",
-    listener: (manualTasks: JiraTicket[]) => void
+    listener: (manualTasks: ProjectTicket[]) => void
   ): () => void;
   on(channel: string, listener: (...args: any[]) => void): () => void;
 


### PR DESCRIPTION
Updates all references from "Jira" to "Project" throughout the codebase to make the application more generic and vendor-neutral. This change enables broader adoption and removes direct association with specific project management tools.

Includes updates to:
- Application name and identifiers
- Documentation and README
- Internal data structures and function names
- User interface text and tooltips

Version bumped to 1.0.1 to reflect rebranding changes.